### PR TITLE
Update readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Installation
 
 ```bash
-go get github.com/rinchsan/gosimports/cmd/gosimports
+go install github.com/rinchsan/gosimports/cmd/gosimports@latest
 ```
 
 ## Example


### PR DESCRIPTION
- Update installation command from `go get` to `go install`﻿
- Drop support for go version 1.13 and 1.14
