### PR TITLE
Adding support for s390x and ppc64le

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,17 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
+      - ppc64le
+    ignore:
+      - goos: darwin
+        goarch: s390x
+      - goos: darwin
+        goarch: ppc64le
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
 brews:
   - name: gosimports
     tap:


### PR DESCRIPTION
This PR adds support for `s390x` and `ppc64le` architectures for Linux. 

Testing was done and verified on #92 

Closes #92 


@rinchsan Let me know if you need anything else to merge this PR. After merging, are you able to cut a new release of the package? 